### PR TITLE
Fix mod for latest steammodded

### DIFF
--- a/balatro.lua
+++ b/balatro.lua
@@ -1,117 +1,159 @@
---- STEAMODDED HEADER
---- MOD_NAME: Balatro Collab
---- MOD_ID: BALXBAL
---- MOD_AUTHOR: [Kitty (Kittyknight. on discord)]
---- MOD_DESCRIPTION: Finally, Balatro is collaborating with the hit indie game Balatro
+SMODS.Atlas {
+    key = "balatro_hearts_1",
+    path = "balatro_hearts_1.png",
+    px = 71,
+    py = 95,
+    atlas_table = "ASSET_ATLAS"
+}
+SMODS.Atlas {
+    key = "balatro_hearts_2",
+    path = "balatro_hearts_2.png",
+    px = 71,
+    py = 95,
+    atlas_table = "ASSET_ATLAS"
+}
 
-SMODS.Atlas{
-            key = "balatro_hearts_1",
-            path = "balatro_hearts_1.png",
-            px = 71,
-            py = 95,
-            atlas_table = "ASSET_ATLAS"
-        }
-SMODS.Atlas{
-            key = "balatro_hearts_2",
-            path = "balatro_hearts_2.png",
-            px = 71,
-            py = 95,
-            atlas_table = "ASSET_ATLAS"
-        }
+SMODS.Atlas {
+    key = "balatro_spades_1",
+    path = "balatro_spades_1.png",
+    px = 71,
+    py = 95,
+    atlas_table = "ASSET_ATLAS"
+}
 
-SMODS.Atlas{
-            key = "balatro_spades_1",
-            path = "balatro_spades_1.png",
-            px = 71,
-            py = 95,
-            atlas_table = "ASSET_ATLAS"
-        }
+SMODS.Atlas {
+    key = "balatro_spades_2",
+    path = "balatro_spades_2.png",
+    px = 71,
+    py = 95,
+    atlas_table = "ASSET_ATLAS"
+}
 
-SMODS.Atlas{
-            key = "balatro_spades_2",
-            path = "balatro_spades_2.png",
-            px = 71,
-            py = 95,
-            atlas_table = "ASSET_ATLAS"
-        }
+SMODS.Atlas {
+    key = "balatro_diamonds_1",
+    path = "balatro_diamonds_1.png",
+    px = 71,
+    py = 95,
+    atlas_table = "ASSET_ATLAS"
+}
 
-SMODS.Atlas{
-            key = "balatro_diamonds_1",
-            path = "balatro_diamonds_1.png",
-            px = 71,
-            py = 95,
-            atlas_table = "ASSET_ATLAS"
-        }
+SMODS.Atlas {
+    key = "balatro_diamonds_2",
+    path = "balatro_diamonds_2.png",
+    px = 71,
+    py = 95,
+    atlas_table = "ASSET_ATLAS"
+}
 
-SMODS.Atlas{
-            key = "balatro_diamonds_2",
-            path = "balatro_diamonds_2.png",
-            px = 71,
-            py = 95,
-            atlas_table = "ASSET_ATLAS"
-        }
+SMODS.Atlas {
+    key = "balatro_clubs_1",
+    path = "balatro_clubs_1.png",
+    px = 71,
+    py = 95,
+    atlas_table = "ASSET_ATLAS"
+}
 
-SMODS.Atlas{
-            key = "balatro_clubs_1",
-            path = "balatro_clubs_1.png",
-            px = 71,
-            py = 95,
-            atlas_table = "ASSET_ATLAS"
-        }
-
-SMODS.Atlas{
-            key = "balatro_clubs_2",
-            path = "balatro_clubs_2.png",
-            px = 71,
-            py = 95,
-            atlas_table = "ASSET_ATLAS"
-        }
+SMODS.Atlas {
+    key = "balatro_clubs_2",
+    path = "balatro_clubs_2.png",
+    px = 71,
+    py = 95,
+    atlas_table = "ASSET_ATLAS"
+}
 
 
-SMODS.DeckSkin{
-            key = "balatro_hearts",
-            suit = "Hearts",
-            ranks =  {"Jack", "Queen", "King"},
-            lc_atlas = "balatro_hearts_1",
-            hc_atlas = "balatro_hearts_2",
-            loc_txt = {
-				["en-us"] = "Balatro Hearts"
-			},
-            posStyle = "collab"
+SMODS.DeckSkin {
+    key = "balatro_hearts",
+    suit = "Hearts",
+    palettes = {
+        {
+            key = 'lc',
+            ranks = { "Jack", "Queen", "King" },
+            display_ranks = { "Jack", "Queen", "King" },
+            atlas = "balatro_hearts_1",
+            pos_style = "collab"
+        },
+        {
+            key = 'hc',
+            ranks = { "Jack", "Queen", "King" },
+            display_ranks = { "Jack", "Queen", "King" },
+            atlas = "balatro_hearts_2",
+            pos_style = "collab"
         }
+    },
+    loc_txt = {
+        ["en-us"] = "Balatro"
+    },
+}
 
-SMODS.DeckSkin{
-            key = "balatro_spades",
-            suit = "Spades",
-            ranks =  {"Jack", "Queen", "King"},
-            lc_atlas = "balatro_spades_1",
-            hc_atlas = "balatro_spades_2",
-            loc_txt = {
-				["en-us"] = "Balatro Spades"
-			},
-            posStyle = "collab"
+SMODS.DeckSkin {
+    key = "balatro_spades",
+    suit = "Spades",
+    palettes = {
+        {
+            key = 'lc',
+            ranks = { "Jack", "Queen", "King" },
+            display_ranks = { "Jack", "Queen", "King" },
+            atlas = "balatro_spades_1",
+            pos_style = "collab"
+        },
+        {
+            key = 'hc',
+            ranks = { "Jack", "Queen", "King" },
+            display_ranks = { "Jack", "Queen", "King" },
+            atlas = "balatro_spades_2",
+            pos_style = "collab"
         }
+    },
+    loc_txt = {
+        ["en-us"] = "Balatro"
+    },
+}
 
-SMODS.DeckSkin{
-            key = "balatro_diamonds",
-            suit = "Diamonds",
-            ranks =  {"Jack", "Queen", "King"},
-            lc_atlas = "balatro_diamonds_1",
-            hc_atlas = "balatro_diamonds_2",
-            loc_txt = {
-				["en-us"] = "Balatro Diamonds"
-			},
-            posStyle = "collab"
+SMODS.DeckSkin {
+    key = "balatro_diamonds",
+    suit = "Diamonds",
+    palettes = {
+        {
+            key = 'lc',
+            ranks = { "Jack", "Queen", "King" },
+            display_ranks = { "Jack", "Queen", "King" },
+            atlas = "balatro_diamonds_1",
+            pos_style = "collab"
+        },
+        {
+            key = 'hc',
+            ranks = { "Jack", "Queen", "King" },
+            display_ranks = { "Jack", "Queen", "King" },
+            atlas = "balatro_diamonds_2",
+            pos_style = "collab"
         }
+    },
+    loc_txt = {
+        ["en-us"] = "Balatro"
+    },
+}
 
-SMODS.DeckSkin{
-            key = "balatro_clubs",
-            suit = "Clubs",
-            ranks =  {"Jack", "Queen", "King"},
-            lc_atlas = "balatro_clubs_1",
-            hc_atlas = "balatro_clubs_2",
-            loc_txt = {
-				["en-us"] = "Balatro Clubs"
-			},
-            posStyle = "collab"
+SMODS.DeckSkin {
+    key = "balatro_clubs",
+    suit = "Clubs",
+    palettes = {
+        {
+            key = 'lc',
+            ranks = { "Jack", "Queen", "King" },
+            display_ranks = { "Jack", "Queen", "King" },
+            atlas = "balatro_clubs_1",
+            pos_style = "collab"
+        },
+        {
+            key = 'hc',
+            ranks = { "Jack", "Queen", "King" },
+            display_ranks = { "Jack", "Queen", "King" },
+            atlas = "balatro_clubs_2",
+            pos_style = "collab"
         }
+    },
+    loc_txt = {
+        ["en-us"] = "Balatro"
+    },
+}

--- a/balatroxbalatro.json
+++ b/balatroxbalatro.json
@@ -1,0 +1,12 @@
+{
+	"id": "BALXBAL",
+	"name": "Balatro Collab",
+	"author": ["Kitty (Kittyknight. on discord)"],
+	"description": "Finally, Balatro is collaborating with the hit indie game Balatro.",
+	"prefix": "balx",
+	"main_file": "balatro.lua",
+	"version": "1.0.1",
+	"dependencies": [
+		"Steamodded (>=1.0.0~ALPHA-1403a)"
+	]
+}


### PR DESCRIPTION
Newest update changes the way DeckSkins are implemented, causing this mod's cards to show as blank.

This PR just updates the DeckSkin objects to use the newest implementation.

It also moves metadata to a separate file, in part to make it easier to set the newest steammodded as a dependency (these changes are not currently backwards compatible).